### PR TITLE
Fix image preview mismatch

### DIFF
--- a/app/og-simulator-client-new.tsx
+++ b/app/og-simulator-client-new.tsx
@@ -695,30 +695,34 @@ export default function OGSimulatorClientNew() {
                   Social Media Preview
                 </CardTitle>
                 <CardDescription>
-                  How your content will appear when shared (first image)
+                  How your content will appear when shared (first valid image)
                 </CardDescription>
               </CardHeader>
               <CardContent>
                 <div className="border rounded-lg p-4 bg-white dark:bg-gray-800 space-y-3">
-                  {images.length > 0 && getImageUrl(images[0]) && (
-                    <div className="w-full h-48 bg-gray-200 dark:bg-gray-700 rounded flex items-center justify-center overflow-hidden">
-                      <img
-                        src={getImageUrl(images[0]) || ''}
-                        alt="OG Image"
-                        className="w-full h-full object-cover"
-                        onError={(e) => {
-                          e.currentTarget.style.display = 'none'
-                          const nextElement = e.currentTarget.nextElementSibling as HTMLElement
-                          if (nextElement) {
-                            nextElement.style.display = 'flex'
-                          }
-                        }}
-                      />
-                      <div className="hidden w-full h-full bg-gray-200 dark:bg-gray-700 items-center justify-center text-gray-500">
-                        Image not found
+                  {(() => {
+                    const firstValidImage = images.find((img) => getImageUrl(img))
+                    const firstValidUrl = firstValidImage ? getImageUrl(firstValidImage) : null
+                    return firstValidUrl ? (
+                      <div className="w-full h-48 bg-gray-200 dark:bg-gray-700 rounded flex items-center justify-center overflow-hidden">
+                        <img
+                          src={firstValidUrl || ''}
+                          alt="OG Image"
+                          className="w-full h-full object-cover"
+                          onError={(e) => {
+                            e.currentTarget.style.display = 'none'
+                            const nextElement = e.currentTarget.nextElementSibling as HTMLElement
+                            if (nextElement) {
+                              nextElement.style.display = 'flex'
+                            }
+                          }}
+                        />
+                        <div className="hidden w-full h-full bg-gray-200 dark:bg-gray-700 items-center justify-center text-gray-500">
+                          Image not found
+                        </div>
                       </div>
-                    </div>
-                  )}
+                    ) : null
+                  })()}
                   <div>
                     <div className="font-semibold text-blue-600 dark:text-blue-400 text-sm mb-1">
                       {metaTags.find(tag => tag.name === 'og:site_name')?.value || 'No site name'}
@@ -748,7 +752,10 @@ export default function OGSimulatorClientNew() {
               <CardContent>
                 <div className="bg-gray-900 text-green-400 p-4 rounded-lg font-mono text-sm overflow-x-auto">
                   <pre className="whitespace-pre-wrap">
-{`<!-- Basic Meta Tags -->
+{(() => {
+  const firstValidImage = images.find((img) => getImageUrl(img, true))
+  const firstValidUrlAbs = firstValidImage ? getImageUrl(firstValidImage, true) : ''
+  return `<!-- Basic Meta Tags -->
 <meta property="og:title" content="${title || 'Test Page Title'}" />
 <meta property="og:description" content="${description || 'Test page description for OG tag generation'}" />
 ${metaTags.map(tag => `<meta property="${tag.name}" content="${tag.value}" />`).join('\n')}
@@ -763,12 +770,15 @@ ${images.map((image, index) => {
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="${title || 'Test Page Title'}" />
 <meta name="twitter:description" content="${description || 'Test page description for OG tag generation'}" />
-${images.length > 0 && getImageUrl(images[0], true) ? `<meta name="twitter:image" content="${getImageUrl(images[0], true)}" />` : ''}`}
+${firstValidUrlAbs ? `<meta name="twitter:image" content="${firstValidUrlAbs}" />` : ''}`
+})()}
                   </pre>
                 </div>
                 <div className="mt-3 flex gap-2">
                   <Button
                     onClick={async () => {
+                      const firstValidImage = images.find((img) => getImageUrl(img, true))
+                      const firstValidUrlAbs = firstValidImage ? getImageUrl(firstValidImage, true) : ''
                       const metaHtml = `<!-- Basic Meta Tags -->
 <meta property="og:title" content="${title || 'Test Page Title'}" />
 <meta property="og:description" content="${description || 'Test page description for OG tag generation'}" />
@@ -784,7 +794,7 @@ ${images.map((image, index) => {
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="${title || 'Test Page Title'}" />
 <meta name="twitter:description" content="${description || 'Test page description for OG tag generation'}" />
-${images.length > 0 && getImageUrl(images[0], true) ? `<meta name="twitter:image" content="${getImageUrl(images[0], true)}" />` : ''}`
+${firstValidUrlAbs ? `<meta name="twitter:image" content="${firstValidUrlAbs}" />` : ''}`
 
                       await navigator.clipboard.writeText(metaHtml)
                       toast.success('Meta tags HTML copied to clipboard!')

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -79,11 +79,11 @@ export async function generateMetadata({ searchParams }: {
 
     if (imageUrl && imageType === 'external') {
       // External image with proxy
-      finalImageUrl = `${baseUrl}/api/image-proxy?url=${encodeURIComponent(imageUrl)}&delay=${parseInt(imageDelay) * 1000}`
+      finalImageUrl = `${baseUrl}/api/image-proxy?url=${encodeURIComponent(imageUrl)}&delay=${parseInt(imageDelay)}`
     } else if (imageType === 'generate' || imageSize || imageWidth || imageHeight) {
       // Generated image
       const imgParams = new URLSearchParams()
-      imgParams.set('delay', (parseInt(imageDelay) * 1000).toString())
+      imgParams.set('delay', parseInt(imageDelay).toString())
       if (imageSize && imageSize !== 'custom') {
         imgParams.set('size', imageSize)
       } else {


### PR DESCRIPTION
Fix social media preview to use the first valid image and correct delay units for image APIs.

Previously, the social media preview and Twitter meta tag would attempt to use `images[0]`, which could be an invalid or empty image, leading to a blank or incorrect preview. This change ensures the first *valid* image (one that produces a usable URL) is selected. Additionally, the delay parameter passed to `/api/image-proxy` and `/api/generate-image` was incorrectly multiplied by 1000, sending milliseconds instead of the expected seconds, which could cause unexpected timing behavior. This has been corrected.

---
<a href="https://cursor.com/background-agent?bcId=bc-e18ede2a-69c5-4920-8844-4347d8bb033b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e18ede2a-69c5-4920-8844-4347d8bb033b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

